### PR TITLE
Fix install command

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -67,7 +67,7 @@ title: "Happy Jekylling!"
     <p>After node.js is installed, simply download sboltools and add the sbol script to an appropriate location.  A two-liner:</p>
 
 <pre>
-curl -L https://github.com/sboltools/sboltools/releases/latest/download/sboltools-unix.zip | tar xz
+curl -L https://github.com/sboltools/sboltools/releases/latest/download/sboltools-unix.zip | unzip
 sudo cp -f sbol /usr/local/bin/
 </pre>
 


### PR DESCRIPTION
This is a .zip file (rather than a .tar.gz), so trying to extract with `tar xz` gives the error:

```
tar: This does not look like a tar archive
tar: Skipping to next header
tar: Exiting with failure status due to previous errors
```